### PR TITLE
Remove package vulnerable to dependency confusion.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 dateutils
 requests==2.18.4
-megatron-lm


### PR DESCRIPTION
A software supply-chain vulnerability has been detected in this repository. Remove PyPI package `megatron-lm` as it is vulnerable to dependency confusion attack: It does on exist on PyPI, and could be taken over by an attacker. 

Powered by **Packj** 
https://github.com/ossillate-inc/packj